### PR TITLE
fix #1120

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_IndustrialAlchemyTower.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_IndustrialAlchemyTower.java
@@ -201,7 +201,7 @@ public class TST_IndustrialAlchemyTower extends GTCM_MultiMachineBase<TST_Indust
                         }
                     }
 
-                    if (aspectMaxParallel.get(aspect) == 0) {
+                    if (aspectMaxParallel.getOrDefault(aspect, 0) == 0) {
                         return Essentia_InsentiaL;
                     }
                 }


### PR DESCRIPTION
经过测试是当配方需要AE网络中不足1流程的源质时TST_IndustrialAlchemyTower.java:204会导致NPE，与存储输入总线无关