### PR TITLE
Fix Astral Computing Array

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_Computer.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_Computer.java
@@ -1154,7 +1154,10 @@ public class TST_Computer extends TT_MultiMachineBase_EM implements ISurvivalCon
             else if (coolant != null && coolant.getFluid() == fluid.getFluid()) coolant.amount += fluid.amount;
         }
         // LOG.info("coolant is null?" + (coolant == null));
-        if (coolant == null) return prevHeat;
+        if (coolant == null || coolant.amount <= 0) {
+            multiplier = 1.0;
+            return prevHeat;
+        }
         double maxHeatCanCool = validCoolant(coolant) * coolant.amount;
         multiplier = 1.0 + Math.log10(1.0 + maxHeatCanCool * prevHeat);
         long realHeatCanCool = (int) Math.min(maxHeatCanCool, (prevHeat - (prevHeat / (multiplier * multiplier))));


### PR DESCRIPTION
现版本的星规阵列在输入仓没有冷却流体的时候超频比会锁定在最后一次消耗，已修复