### PR TITLE
更多的巨型装配线配方

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/AssemblyLineWithoutResearchRecipePool.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/machineRecipe/expanded/AssemblyLineWithoutResearchRecipePool.java
@@ -505,7 +505,6 @@ public class AssemblyLineWithoutResearchRecipePool {
             TST_RecipeBuilder.builder()
                 .itemInputs(
                     GTUtility.getIntegratedCircuit(10),
-                    GTUtility.getIntegratedCircuit(10),
                     ItemList.Circuit_Board_Bio_Ultra.get(2),
                     ItemList.Circuit_Biowarecomputer.get(2),
                     ItemList.Circuit_Parts_TransistorASMD.get(16),


### PR DESCRIPTION
全部用10号电路板,数值全部照搬原版装配线配方.这些配方应该可以平滑地过渡到奇迹顶点.