### PR TITLE
fix BigBroArray's MaxParallelism

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_BigBroArray.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_BigBroArray.java
@@ -1785,7 +1785,7 @@ public class TST_BigBroArray extends TT_MultiMachineBase_EM implements ISurvival
         if (addonCount > 0) {
             long infinity = 2147483647L << casingMultiplier;
             return parallelismTier >= 5 ? (infinity / 5) * (1 + this.addonCount)
-                : (64L << ((parallelismTier) * 2)) * (1 + this.addonCount);
+                : (64L << ((casingMultiplier) * 2)) * (1 + this.addonCount);
         } else {
             return 64;
         }


### PR DESCRIPTION
fix BigBroArray's MaxParallelism when using T4 parallelism casing so  MaxParallelism is 5,242,880 instead of 81920, matches tooltip's description