### PR TITLE
Fix GTNH 2.9 beta2 world-open crash from removed BioItemList helper

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/GTCMMachineRecipes.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/recipe/craftRecipe/machine/GTCMMachineRecipes.java
@@ -190,7 +190,6 @@ import com.dreammaster.item.NHItemList;
 
 import appeng.api.AEApi;
 import appeng.items.materials.MaterialType;
-import bartworks.common.loaders.BioItemList;
 import bartworks.common.loaders.ItemRegistry;
 import bartworks.system.material.CircuitGeneration.CircuitPartsItem;
 import bartworks.system.material.WerkstoffLoader;
@@ -1526,7 +1525,7 @@ public class GTCMMachineRecipes {
             .itemInputs(
                 GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Osmiridium, 64),
                 GTUtility.copyAmountUnsafe(64, bioVat),
-                GTUtility.copyAmountUnsafe(64, BioItemList.getPetriDish(null)),
+                GTUtility.copyAmountUnsafe(64, new ItemStack(GameRegistry.findItem("bartworks", "BioLabParts"))),
                 GTOreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Infinity, 3),
 
                 ItemList.Electric_Pump_UHV.get(16),


### PR DESCRIPTION
## Summary
- replace the removed `BioItemList.getPetriDish(null)` call with a direct `bartworks:BioLabParts` lookup
- keep the recipe intent the same: request the plain petri dish item

## Why
GTNH 2.9.0-beta-2 removed the old BartWorks helper method, which causes a `NoSuchMethodError` during world open in Twist Space `0.8.0-beta1.1`.

## Verification
- built the patched `0.8.0-beta1.1` source successfully
- tested the resulting jar in GTNH `2.9.0-beta-2`
- clean launch into world, no missing-block warning, no crash

Closes #1266