### PR TITLE
修复熯焱高炉升温模式和热保持模式互斥

### DIFF
--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_SwelegfyrBlastFurnace.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/TST_SwelegfyrBlastFurnace.java
@@ -557,12 +557,15 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
                     return CheckRecipeResults.RapidHeating;
                 } else {
                     // Heating finish, as holding mode running
-                    correctBlazeCost = mHeatingCapacity / 20;
-                    if (!drainPyrotheumFromBlazeHatch(correctBlazeCost * 10, true))
-                        return shutDownOfMissingPyrotheum(correctBlazeCost * 10);
-
-                    duration = 200;
-                    return CheckRecipeResults.RapidHeatFinish;
+                    // correctBlazeCost = mHeatingCapacity / 20;
+                    // if (!drainPyrotheumFromBlazeHatch(correctBlazeCost * 10, true))
+                    // return shutDownOfMissingPyrotheum(correctBlazeCost * 10);
+                    //
+                    // duration = 200;
+                    // return CheckRecipeResults.RapidHeatFinish;
+                    isRapidHeating = false;
+                    isHoldingHeat = true;
+                    return CheckRecipeResultRegistry.NO_RECIPE;
                 }
             }
 
@@ -851,6 +854,7 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
 
     public void setRapidHeating(boolean b) {
         isRapidHeating = b;
+        if (b) isHoldingHeat = false;
     }
 
     // public ButtonWidget createHoldingHeatButton(IWidgetBuilder<?> builder) {
@@ -898,6 +902,7 @@ public class TST_SwelegfyrBlastFurnace extends GTCM_MultiMachineBase<TST_Swelegf
 
     public void setHoldingHeat(boolean b) {
         isHoldingHeat = b;
+        if (b) isRapidHeating = false;
     }
 
     @Override

--- a/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/UI/MUI2/TST_Gui_SwelegfyrBlastFurnace.java
+++ b/src/main/java/com/Nxer/TwistSpaceTechnology/common/machine/UI/MUI2/TST_Gui_SwelegfyrBlastFurnace.java
@@ -12,7 +12,6 @@ import net.minecraft.util.StatCollector;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.Nxer.TwistSpaceTechnology.TwistSpaceTechnology;
 import com.Nxer.TwistSpaceTechnology.common.machine.TST_SwelegfyrBlastFurnace;
 import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.drawable.DynamicDrawable;
@@ -49,11 +48,11 @@ public class TST_Gui_SwelegfyrBlastFurnace extends TST_Gui<TST_SwelegfyrBlastFur
     }
 
     public IWidget createRapidHeatingButton(PanelSyncManager syncManager) {
-        IntSyncValue machineModeSyncer = (IntSyncValue) syncManager.getSyncHandlerFromMapKey("machineMode:0");
-        BooleanSyncValue rapidHeatingButtonSyncer = (BooleanSyncValue) syncManager
-            .getSyncHandlerFromMapKey("rapidHeatingButtonSyncer:0");
-        BooleanSyncValue updatedMachineGetter = (BooleanSyncValue) syncManager
-            .getSyncHandlerFromMapKey("updatedMachineGetter:0");
+        IntSyncValue machineModeSyncer = syncManager.findSyncHandler("machineMode", IntSyncValue.class);
+        BooleanSyncValue rapidHeatingButtonSyncer = syncManager
+            .findSyncHandler("rapidHeatingButtonSyncer", BooleanSyncValue.class);
+        BooleanSyncValue updatedMachineGetter = syncManager
+            .findSyncHandler("updatedMachineGetter", BooleanSyncValue.class);
 
         return new ToggleButton() {
 
@@ -66,11 +65,9 @@ public class TST_Gui_SwelegfyrBlastFurnace extends TST_Gui<TST_SwelegfyrBlastFur
         }.size(18, 18)
             .value(rapidHeatingButtonSyncer)
             .overlay(new DynamicDrawable(() -> {
-                TwistSpaceTechnology.LOG.info("updatedMachineGetter.getValue() = {}", updatedMachineGetter.getValue());
                 if (!updatedMachineGetter.getValue() || machineModeSyncer.getValue() != 1) {
                     return SBF_RapidHeating_Forbidden;
                 }
-
                 return rapidHeatingButtonSyncer.getValue() ? SBF_RapidHeating_On : SBF_RapidHeating_Off;
             }))
             .tooltipBuilder(a -> a.add(StatCollector.translateToLocal("SBF.Msg.enableRapidHeating")));
@@ -80,11 +77,11 @@ public class TST_Gui_SwelegfyrBlastFurnace extends TST_Gui<TST_SwelegfyrBlastFur
     }
 
     public IWidget createHoldingHeatButton(PanelSyncManager syncManager) {
-        IntSyncValue machineModeSyncer = (IntSyncValue) syncManager.getSyncHandlerFromMapKey("machineMode:0");
-        BooleanSyncValue updatedMachineGetter = (BooleanSyncValue) syncManager
-            .getSyncHandlerFromMapKey("updatedMachineGetter:0");
-        BooleanSyncValue holdingHeatButtonSyncer = (BooleanSyncValue) syncManager
-            .getSyncHandlerFromMapKey("holdingHeatButtonSyncer:0");
+        IntSyncValue machineModeSyncer = syncManager.findSyncHandler("machineMode", IntSyncValue.class);
+        BooleanSyncValue updatedMachineGetter = syncManager
+            .findSyncHandler("updatedMachineGetter", BooleanSyncValue.class);
+        BooleanSyncValue holdingHeatButtonSyncer = syncManager
+            .findSyncHandler("holdingHeatButtonSyncer", BooleanSyncValue.class);
 
         return new ToggleButton() {
 


### PR DESCRIPTION
恢复原先升温模式和保温模式互斥的逻辑,另外原先升温模式满温度后会持续执行一个10s的等价的保温模式配方这有些奇怪,而且会卡住正常配方的执行,我让其直接转为保温模式.